### PR TITLE
Fix resource notifying

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "k@treasure-data.com"
 license          "Apache 2.0"
 description      "Installs/Configures td-agent"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.4.0"
+version          "3.5.0"
 recipe           "td-agent", "td-agent configuration"
 
 chef_version     ">= 12" if respond_to?(:chef_version)

--- a/providers/filter.rb
+++ b/providers/filter.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+use_inline_resources
 include ::TdAgent::Version
 
 action :create do
@@ -61,7 +62,7 @@ end
 def reload_action
   if reload_available?
     :reload
-  else 
+  else
     :restart
   end
 end

--- a/providers/filter.rb
+++ b/providers/filter.rb
@@ -25,7 +25,7 @@ include ::TdAgent::Version
 action :create do
   fail 'You should set the node[:td_agent][:includes] attribute to true to use this resource.' unless node['td_agent']['includes']
 
-  t = template "/etc/td-agent/conf.d/#{new_resource.filter_name}.conf" do
+  template "/etc/td-agent/conf.d/#{new_resource.filter_name}.conf" do
     source 'filter.conf.erb'
     owner 'root'
     group 'root'
@@ -45,18 +45,14 @@ action :create do
     cookbook 'td-agent'
     notifies reload_action, 'service[td-agent]'
   end
-
-  new_resource.updated_by_last_action(true) if t.updated_by_last_action?
 end
 
 action :delete do
-  f = file "/etc/td-agent/conf.d/#{new_resource.filter_name}.conf" do
+  file "/etc/td-agent/conf.d/#{new_resource.filter_name}.conf" do
     action :delete
     only_if { ::File.exist?("/etc/td-agent/conf.d/#{new_resource.filter_name}.conf") }
     notifies reload_action, 'service[td-agent]'
   end
-
-  new_resource.updated_by_last_action(true) if f.updated_by_last_action?
 end
 
 def reload_action

--- a/providers/match.rb
+++ b/providers/match.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+use_inline_resources
 include ::TdAgent::Version
 
 action :create do

--- a/providers/match.rb
+++ b/providers/match.rb
@@ -25,7 +25,7 @@ include ::TdAgent::Version
 action :create do
   fail 'You should set the node[:td_agent][:includes] attribute to true to use this resource.' unless node['td_agent']['includes']
 
-  t = template "/etc/td-agent/conf.d/#{new_resource.match_name}.conf" do
+  template "/etc/td-agent/conf.d/#{new_resource.match_name}.conf" do
     source 'match.conf.erb'
     owner 'root'
     group 'root'
@@ -45,18 +45,14 @@ action :create do
     cookbook 'td-agent'
     notifies reload_action, 'service[td-agent]'
   end
-
-  new_resource.updated_by_last_action(true) if t.updated_by_last_action?
 end
 
 action :delete do
-  f = file "/etc/td-agent/conf.d/#{new_resource.match_name}.conf" do
+  file "/etc/td-agent/conf.d/#{new_resource.match_name}.conf" do
     action :delete
     only_if { ::File.exist?("/etc/td-agent/conf.d/#{new_resource.match_name}.conf") }
     notifies reload_action, 'service[td-agent]'
   end
-
-  new_resource.updated_by_last_action(true) if f.updated_by_last_action?
 end
 
 def reload_action

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -18,6 +18,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+use_inline_resources
 
 action :create do
   d = directory '/etc/td-agent/plugin' do

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -21,16 +21,14 @@
 use_inline_resources
 
 action :create do
-  d = directory '/etc/td-agent/plugin' do
+  directory '/etc/td-agent/plugin' do
     owner "root"
     group "root"
     mode "0755"
     action :create
   end
 
-  new_resource.updated_by_last_action(true) if d.updated_by_last_action?
-
-  r = remote_file "/etc/td-agent/plugin/#{new_resource.plugin_name}.rb" do
+  remote_file "/etc/td-agent/plugin/#{new_resource.plugin_name}.rb" do
     action :create_if_missing unless new_resource.checksum
     action :create if new_resource.checksum
     checksum new_resource.checksum if new_resource.checksum
@@ -40,16 +38,12 @@ action :create do
     source new_resource.url
     notifies :restart, "service[td-agent]"
   end
-
-  new_resource.updated_by_last_action(true) if r.updated_by_last_action?
 end
 
 action :delete do
-  f = file "/etc/td-agent/plugin/#{new_resource.plugin_name}.rb" do
+  file "/etc/td-agent/plugin/#{new_resource.plugin_name}.rb" do
     action :delete
     only_if { ::File.exist?("/etc/td-agent/plugin/#{new_resource.plugin_name}.rb") }
     notifies :restart, "service[td-agent]"
   end
-
-  new_resource.updated_by_last_action(true) if f.updated_by_last_action?
 end

--- a/providers/source.rb
+++ b/providers/source.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+use_inline_resources
 include ::TdAgent::Version
 
 action :create do

--- a/providers/source.rb
+++ b/providers/source.rb
@@ -25,7 +25,7 @@ include ::TdAgent::Version
 action :create do
   fail 'You should set the node[:td_agent][:includes] attribute to true to use this resource.' unless node['td_agent']['includes']
 
-  t = template "/etc/td-agent/conf.d/#{new_resource.source_name}.conf" do
+  template "/etc/td-agent/conf.d/#{new_resource.source_name}.conf" do
     source 'source.conf.erb'
     owner 'root'
     group 'root'
@@ -45,18 +45,14 @@ action :create do
     cookbook new_resource.template_source
     notifies reload_action, 'service[td-agent]'
   end
-
-  new_resource.updated_by_last_action(true) if t.updated_by_last_action?
 end
 
 action :delete do
-  f = file "/etc/td-agent/conf.d/#{new_resource.source_name}.conf" do
+  file "/etc/td-agent/conf.d/#{new_resource.source_name}.conf" do
     action :delete
     only_if { ::File.exist?("/etc/td-agent/conf.d/#{new_resource.source_name}.conf") }
     notifies reload_action, 'service[td-agent]'
   end
-
-  new_resource.updated_by_last_action(true) if f.updated_by_last_action?
 end
 
 def reload_action


### PR DESCRIPTION
This fixes resource notifying. 

* Added [use_inline_resources](https://docs-archive.chef.io/release/12-0/custom_resources.html#use-inline-resources) to providers
* Removed [updated_by_last_action](https://docs.chef.io/custom_resources_notes/#updated_by_last_action) - not used, not needed

Notify in the following example will not work without this fix.
```ruby
td_agent_source 'dummy' do
  type 'dummy'
  parameters( dummy: 'hello world' )
  notifies :restart, 'service[dummy-service]', :immediately
end
```

Thanks @vytstank for help!
@vinted/sre