### PR TITLE
Add support for td-agent4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,14 @@ env:
 #   - TEST_INSTANCE=2x-chef12-ubuntu-xenial
 #   - TEST_INSTANCE=2x-chef12-centos-centos6
 #   - TEST_INSTANCE=2x-chef12-centos-centos7
-    - TEST_INSTANCE=2x-chef13-ubuntu-xenial
-    - TEST_INSTANCE=2x-chef13-centos-centos6
+#   - TEST_INSTANCE=2x-chef13-ubuntu-xenial
+#   - TEST_INSTANCE=2x-chef13-centos-centos6
     - TEST_INSTANCE=2x-chef13-centos-centos7
 #   - TEST_INSTANCE=3x-chef12-ubuntu-xenial
 #   - TEST_INSTANCE=3x-chef12-centos-centos6
 #   - TEST_INSTANCE=3x-chef12-centos-centos7
-    - TEST_INSTANCE=3x-chef13-ubuntu-xenial
-    - TEST_INSTANCE=3x-chef13-centos-centos6
+#   - TEST_INSTANCE=3x-chef13-ubuntu-xenial
+#   - TEST_INSTANCE=3x-chef13-centos-centos6
     - TEST_INSTANCE=3x-chef13-centos-centos7
 
 script:

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "k@treasure-data.com"
 license          "Apache 2.0"
 description      "Installs/Configures td-agent"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.6.0"
+version          "3.7.0"
 recipe           "td-agent", "td-agent configuration"
 
 chef_version     ">= 12" if respond_to?(:chef_version)

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -42,7 +42,7 @@ end
 
 service "td-agent" do
   supports :restart => true, :reload => (reload_action == :reload), :status => true
-  restart_command "/etc/init.d/td-agent restart || /etc/init.d/td-agent start"
+  restart_command "/etc/init.d/td-agent restart || /etc/init.d/td-agent start" if major_version.to_i < 4
   action [ :enable, :start ]
 end
 


### PR DESCRIPTION
## Add support for td-agent4
td-agent4 uses rubygems 3.x which has deprecated `--no-rdoc --no-ri` parameters.
Chef12 does not support rubygems 3.x (support added in Chef14)
This PR adds method override for `install_via_gem_command` from future Chef source code.

Changes:
* Override chef method `install_via_gem_command`. [source](https://github.com/chef/chef/blob/537982312e1034f33e4bc3967f36d8f49bbafb4c/lib/chef/provider/package/rubygems.rb#L550)
* set `td-agent` service not to use init.d commands for td-agent4+
* leave only centos7 instance tests in travisci

@vinted/sre 