### PR TITLE
Fix cookbook fail when upgrading td-agent v3 to v4

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -2,6 +2,11 @@
 driver:
   name: docker
   use_sudo: false
+  run_command: /lib/systemd/systemd
+  cap_add:
+    - SYS_ADMIN
+  volume:
+    - /sys/fs/cgroup
 
 provisioner:
   name: chef_zero
@@ -61,6 +66,14 @@ suites:
     attributes:
       td_agent:
         version: 3.1.0
+    driver_config:
+      require_chef_omnibus: 13.2.20
+    run_list:
+      - recipe[smoke::default]
+  - name: 4x-chef13
+    attributes:
+      td_agent:
+        version: 4.0.1
     driver_config:
       require_chef_omnibus: 13.2.20
     run_list:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,14 @@ env:
 #   - TEST_INSTANCE=2x-chef12-centos-centos7
 #   - TEST_INSTANCE=2x-chef13-ubuntu-xenial
 #   - TEST_INSTANCE=2x-chef13-centos-centos6
-    - TEST_INSTANCE=2x-chef13-centos-centos7
+#   - TEST_INSTANCE=2x-chef13-centos-centos7
 #   - TEST_INSTANCE=3x-chef12-ubuntu-xenial
 #   - TEST_INSTANCE=3x-chef12-centos-centos6
 #   - TEST_INSTANCE=3x-chef12-centos-centos7
 #   - TEST_INSTANCE=3x-chef13-ubuntu-xenial
 #   - TEST_INSTANCE=3x-chef13-centos-centos6
     - TEST_INSTANCE=3x-chef13-centos-centos7
+    - TEST_INSTANCE=4x-chef13-centos-centos7
 
 script:
   - |

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "k@treasure-data.com"
 license          "Apache 2.0"
 description      "Installs/Configures td-agent"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.7.0"
+version          "3.7.1"
 recipe           "td-agent", "td-agent configuration"
 
 chef_version     ">= 12" if respond_to?(:chef_version)

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -30,11 +30,13 @@ node["td_agent"]["plugins"].each do |plugin|
       %w{action version source options gem_binary}.each do |attr|
         send(attr, plugin_attributes[attr]) if plugin_attributes[attr]
       end
+      subsribes :create, 'package[td-agent]', :immediately
       notifies :restart, "service[td-agent]", :delayed
     end
   elsif plugin.is_a?(String)
     td_agent_gem plugin do
       plugin true
+      subsribes :create, 'package[td-agent]', :immediately
       notifies :restart, "service[td-agent]", :delayed
     end
   end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -101,7 +101,7 @@ when "rhel", "amazon"
       else
         "http://packages.treasuredata.com/#{major}/redhat/$releasever/$basearch"
       end
-    when '3'
+    when '3', '4'
       if platform == "amazon"
       amazon_version = node['kernel']['release'].match(/\.amzn([[:digit:]]+)\./)[1]
         "https://packages.treasuredata.com/#{major}/amazon/#{amazon_version}/#{node["td_agent"]["yum_amazon_releasever"]}/$basearch"

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -134,4 +134,11 @@ package "td-agent" do
   else
     action :upgrade
   end
+  notifies :run, 'execute[td-agent-systemctl-daemon-reload]', :immediately
+  notifies :restart, 'service[td-agent]', :delayed
+end
+
+execute 'td-agent-systemctl-daemon-reload' do
+  command '/bin/systemctl daemon-reload'
+  action :nothing
 end


### PR DESCRIPTION
Currently cookbook fails when upgrading td-agent3 -> td-agent4
Reasons:
* `systemctl daemon-reload` not executed
* missing td-agent plugins after upgrade

Fix:
* execute `systemctl daemon-reload` when package upgraded
* check if td-agent plugins needs to be installed when package upgraded

Other changes:
* Fix yum repository configuration for td-agent4
* Add test suite for td-agent4
* Disable test suite for td-agent2
* Add kitchen configuration which enables using systemd in docker

@vinted/sre 