### PR TITLE
Fix td-agent upgrade

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "k@treasure-data.com"
 license          "Apache 2.0"
 description      "Installs/Configures td-agent"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.7.2"
+version          "3.7.3"
 recipe           "td-agent", "td-agent configuration"
 
 chef_version     ">= 12" if respond_to?(:chef_version)

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -44,8 +44,7 @@ end
 
 service "td-agent" do
   supports :restart => true, :reload => (reload_action == :reload), :status => true
-  restart_command "/etc/init.d/td-agent restart || /etc/init.d/td-agent start" if major_version.to_i < 4
-  action [ :enable, :start ]
+  action [ :enable, :nothing ]
 end
 
 ##### /var/log/td-agent


### PR DESCRIPTION
This fixes td-agent3 -> td-agent4 upgrade

Changes:
* change service action `start -> nothing` 
* remove obsolete restart_command

@vinted/sre 