### PR TITLE
Fix Chef16 compatibility

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,6 +13,7 @@ provisioner:
   product_name: chef
   log_level: info
   deprecations_as_errors: true
+  chef_license: accept-no-persist
 
 platforms:
   - name: ubuntu-xenial
@@ -91,6 +92,19 @@ suites:
       provision_command:
         - curl -L https://omnitruck.chef.io/install.sh | bash -s -- -v 13.12.14
         - /opt/chef/embedded/bin/gem install bundler:2.1.4
+    provisioner:
+      install_strategy: skip
+    run_list:
+      - recipe[smoke::default]
+
+  - name: 4x-chef16
+    attributes:
+      td_agent:
+        version: 4.0.1
+    driver_config:
+      require_chef_omnibus: false
+      chef_omnibus_root: /opt/cinc
+      provision_command: curl -L https://omnitruck.chef.io/install.sh | bash -s -- -v 16.13.16
     provisioner:
       install_strategy: skip
     run_list:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,7 +27,7 @@ platforms:
   - name: centos-centos7
     driver_config:
       platform: centos
-      image: centos:centos7
+      image: mirror.gcr.io/library/centos:7
 
 suites:
 # - name: 1x-chef12

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  product_name: chef
   log_level: info
   deprecations_as_errors: true
 
@@ -59,22 +60,38 @@ suites:
       td_agent:
         version: 2.2.0
     driver_config:
-      require_chef_omnibus: 13.2.20
+      require_chef_omnibus: false
+      chef_omnibus_root: /opt/chef
+      provision_command: curl -L https://omnitruck.chef.io/install.sh | bash -s -- -v 13.12.14
+    provisioner:
+      install_strategy: skip
     run_list:
       - recipe[smoke::default]
+
   - name: 3x-chef13
     attributes:
       td_agent:
         version: 3.1.0
     driver_config:
-      require_chef_omnibus: 13.2.20
+      require_chef_omnibus: false
+      chef_omnibus_root: /opt/chef
+      provision_command: curl -L https://omnitruck.chef.io/install.sh | bash -s -- -v 13.12.14
+    provisioner:
+      install_strategy: skip
     run_list:
       - recipe[smoke::default]
+
   - name: 4x-chef13
     attributes:
       td_agent:
         version: 4.0.1
     driver_config:
-      require_chef_omnibus: 13.2.20
+      require_chef_omnibus: false
+      chef_omnibus_root: /opt/chef
+      provision_command:
+        - curl -L https://omnitruck.chef.io/install.sh | bash -s -- -v 13.12.14
+        - /opt/chef/embedded/bin/gem install bundler:2.1.4
+    provisioner:
+      install_strategy: skip
     run_list:
       - recipe[smoke::default]

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
 #   - TEST_INSTANCE=3x-chef13-centos-centos6
     - TEST_INSTANCE=3x-chef13-centos-centos7
     - TEST_INSTANCE=4x-chef13-centos-centos7
+    - TEST_INSTANCE=4x-chef16-centos-centos7
 
 script:
   - |

--- a/libraries/resource_td_agent_gem.rb
+++ b/libraries/resource_td_agent_gem.rb
@@ -3,6 +3,10 @@ require 'chef/resource'
 class Chef
   class Resource
     class TdAgentGem < Chef::Resource::GemPackage
+
+      resource_name :td_agent_gem
+      provides :td_agent_gem
+
       def initialize(*args)
         super
         @action = :install

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "k@treasure-data.com"
 license          "Apache 2.0"
 description      "Installs/Configures td-agent"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.7.3"
+version          "3.7.4"
 recipe           "td-agent", "td-agent configuration"
 
 chef_version     ">= 12" if respond_to?(:chef_version)

--- a/test/integration/4x-chef16/bash/Gemfile
+++ b/test/integration/4x-chef16/bash/Gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org/"
+gem "net-ssh"
+gem "rake"
+gem "rspec_junit_formatter"
+gem "serverspec"
+gem "specinfra"

--- a/test/integration/4x-chef16/bash/Rakefile
+++ b/test/integration/4x-chef16/bash/Rakefile
@@ -1,0 +1,29 @@
+require 'rake'
+require 'rspec/core/rake_task'
+require 'shellwords'
+
+task :spec    => 'spec:all'
+task :default => :spec
+
+namespace :spec do
+  targets = []
+  Dir.glob('./spec/*').each do |dir|
+    next unless File.directory?(dir)
+    target = File.basename(dir)
+    target = "_#{target}" if target == "default"
+    targets << target
+  end
+
+  task :all     => targets
+  task :default => :all
+
+  targets.each do |target|
+    original_target = target == "_default" ? target[1..-1] : target
+    desc "Run serverspec tests to #{original_target}"
+    RSpec::Core::RakeTask.new(target.to_sym) do |t|
+      ENV['TARGET_HOST'] = original_target
+      t.pattern = "spec/#{original_target}/*_spec.rb"
+      t.rspec_opts = Shellwords.shellsplit(ENV["SPEC_OPTS"] || "")
+    end
+  end
+end

--- a/test/integration/4x-chef16/bash/server_spec.bash
+++ b/test/integration/4x-chef16/bash/server_spec.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eux -o pipefail
+unset GEM_CACHE
+unset GEM_HOME
+unset GEM_PATH
+export PATH="/opt/chef/embedded/bin:/opt/chef/bin:${PATH}"
+cd "${BUSSER_ROOT}/suites/bash"
+bundle install --path=vendor/bundle
+env bundle exec rake spec

--- a/test/integration/4x-chef16/bash/spec/localhost/lwrp_spec.rb
+++ b/test/integration/4x-chef16/bash/spec/localhost/lwrp_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'serverspec'
+
+set :backend, :exec
+
+describe package('td-agent') do
+  it { should be_installed }
+end
+
+describe service('td-agent') do
+  it { should be_running }
+end
+
+describe file('/etc/td-agent') do
+  it { should be_a_directory }
+end
+
+describe file('/etc/td-agent/td-agent.conf') do
+  it { should be_a_file }
+  it { should be_mode 644 }
+end
+
+describe file('/etc/td-agent/conf.d') do
+  it { should be_a_directory }
+  it { should be_mode 755 }
+end
+
+describe file('/etc/td-agent/conf.d/test_in_tail.conf') do
+  it { should be_a_file }
+  it { should be_mode 644 }
+  it { should contain "<source>\n  type tail\n  tag syslog\n  format syslog\n  path /var/log/syslog\n</source>" }
+end
+
+describe file('/etc/td-agent/conf.d/test_in_tail_nginx.conf') do
+  it { should be_a_file }
+  it { should be_mode 644 }
+  its(:content) { should match(/^\s*@type\s+tail$/) }
+  its(:content) { should match(/^\s*tag\s+webserver\.nginx$/) }
+  its(:content) { should match(%r{^\s*path\s+/tmp/access\.log$}) }
+  its(:content) { should match(%r{^\s*pos_file\s+/tmp/.access\.log\.pos$}) }
+end
+
+describe file('/etc/td-agent/conf.d/test_section_attributes.conf') do
+  it { should be_a_file }
+  it { should be_mode 644 }
+  its(:content) { should match(/^\s*.type null$/) }
+  its(:content) { should match(/^\s*<buffer tag, argument1, argument2>$/) }
+  its(:content) { should match(%r{^\s*</buffer>$}) }
+end
+
+describe file('/etc/td-agent/conf.d/test_gelf_match.conf') do
+  it { should be_a_file }
+  it { should be_mode 644 }
+  it { should contain "<match webserver.*>\n  type copy\n  <store>\ntype gelf\nhost 127.0.0.1\nport 12201\nflush_interval 5s\n</store>\n<store>\ntype stdout\n</store>\n</match>" }
+end
+
+describe file('/etc/td-agent/conf.d/test_filter.conf') do
+  it { should be_a_file }
+  it { should be_mode 644 }
+  it { should contain %(<filter webserver.*>\n  type record_transformer\n  <record>\host_param "#{Socket.gethostname}"\n</record>\n</filter>) }
+end
+
+describe file('/etc/td-agent/plugin/gelf.rb') do
+  it { should be_a_file }
+  it { should be_mode 644 }
+end
+
+describe command('td-agent --dry-run') do
+  its(:exit_status) { should eq 0 }
+end

--- a/test/integration/4x-chef16/bash/spec/localhost/td-agent_spec.rb
+++ b/test/integration/4x-chef16/bash/spec/localhost/td-agent_spec.rb
@@ -1,0 +1,29 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe package('td-agent') do
+  it { should be_installed }
+end
+
+describe service('td-agent') do
+  it { should be_running }
+end
+
+describe file('/etc/td-agent') do
+  it { should be_a_directory }
+end
+
+describe file('/etc/td-agent/td-agent.conf') do
+  it { should be_a_file }
+  it { should be_mode 644 }
+end
+
+describe file('/etc/td-agent/conf.d') do
+  it { should be_a_directory }
+  it { should be_mode 755 }
+end
+
+describe package('fluent-plugin-time_parser') do
+  it { should_not be_installed.by('gem') }
+end

--- a/test/integration/4x-chef16/bash/spec/spec_helper.rb
+++ b/test/integration/4x-chef16/bash/spec/spec_helper.rb
@@ -1,0 +1,1 @@
+require "serverspec"


### PR DESCRIPTION
Fixes `undefined method `td_agent_gem'` from downstream cookbooks on Chef16.

Tests in downstream cookbooks seem to pass.