### PR TITLE
Remove td_agent_gem `subscribes` notifications for package installation

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "k@treasure-data.com"
 license          "Apache 2.0"
 description      "Installs/Configures td-agent"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "3.7.4"
+version          "3.7.5"
 recipe           "td-agent", "td-agent configuration"
 
 chef_version     ">= 12" if respond_to?(:chef_version)

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -30,13 +30,11 @@ node["td_agent"]["plugins"].each do |plugin|
       %w{action version source options gem_binary}.each do |attr|
         send(attr, plugin_attributes[attr]) if plugin_attributes[attr]
       end
-      subsribes :create, 'package[td-agent]', :immediately
       notifies :restart, "service[td-agent]", :delayed
     end
   elsif plugin.is_a?(String)
     td_agent_gem plugin do
       plugin true
-      subsribes :create, 'package[td-agent]', :immediately
       notifies :restart, "service[td-agent]", :delayed
     end
   end

--- a/test/fixtures/smoke/attributes/default.rb
+++ b/test/fixtures/smoke/attributes/default.rb
@@ -1,0 +1,1 @@
+default["td_agent"]["plugins"] = %w(secure-forward)

--- a/test/integration/3x-chef13/bash/spec/localhost/lwrp_spec.rb
+++ b/test/integration/3x-chef13/bash/spec/localhost/lwrp_spec.rb
@@ -66,6 +66,10 @@ describe file('/etc/td-agent/plugin/gelf.rb') do
   it { should be_mode 644 }
 end
 
+describe command('/opt/td-agent/embedded/bin/gem list -i -e -q --silent fluent-plugin-secure-forward') do
+  its(:exit_status) { should eq 0 }
+end
+
 describe command('td-agent --dry-run') do
   its(:exit_status) { should eq 0 }
 end

--- a/test/integration/4x-chef13/bash/spec/localhost/lwrp_spec.rb
+++ b/test/integration/4x-chef13/bash/spec/localhost/lwrp_spec.rb
@@ -66,6 +66,10 @@ describe file('/etc/td-agent/plugin/gelf.rb') do
   it { should be_mode 644 }
 end
 
+describe command('/opt/td-agent/bin/gem list -i -e -q --silent fluent-plugin-secure-forward') do
+  its(:exit_status) { should eq 0 }
+end
+
 describe command('td-agent --dry-run') do
   its(:exit_status) { should eq 0 }
 end

--- a/test/integration/4x-chef16/bash/spec/localhost/lwrp_spec.rb
+++ b/test/integration/4x-chef16/bash/spec/localhost/lwrp_spec.rb
@@ -66,6 +66,10 @@ describe file('/etc/td-agent/plugin/gelf.rb') do
   it { should be_mode 644 }
 end
 
+describe command('/opt/td-agent/bin/gem list -i -e -q --silent fluent-plugin-secure-forward') do
+  its(:exit_status) { should eq 0 }
+end
+
 describe command('td-agent --dry-run') do
   its(:exit_status) { should eq 0 }
 end


### PR DESCRIPTION
This block never worked in practice:

* typo `:subsribes` -> `:subscribes`
* `td_agent_gem` does not have `action :create`
* if fixed, breaks workflow when `td_agent_gem` is used after td-agent::install in a wrapper and `node["td_agent"]["plugins"]` attributes contain plugins, which will be installed first

Smoke test fluent-plugin installation via node attributes to test previously broken code path.